### PR TITLE
feat(script): add postpaid evs volume modules

### DIFF
--- a/examples/postpaid-evs-volume/README.md
+++ b/examples/postpaid-evs-volume/README.md
@@ -1,0 +1,67 @@
+# Postpaid EVS volume example
+
+Configuration in this directory creates a postpaid EVS volume.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+
+| Name                | Source                                           | Version |
+|---------------------|--------------------------------------------------|---------|
+| postpaid_evs_volume | [evs volume](../../modules/evs-volume/README.md) | N/A     |
+
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name                        | Type     |
+|-----------------------------|----------|
+| huaweicloud_evs_volume.test | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+
+| Name                  | Description                                                      | Value                                                    |
+|-----------------------|------------------------------------------------------------------|----------------------------------------------------------|
+| evs_availability_zone | The availability zone for the EVS volume.                        | `"cn-north-4"`                                           |
+| evs_volume_type       | The EVS volume type.                                             | `"GPSSD2"`                                               |
+| evs_iops              | The IOPS(Input/Output Operations Per Second) for the EVS volume. | `3000`                                                   |
+| evs_throughput        | The throughput for the EVS volume.                               | `125`                                                    |
+| evs_device_type       | The device type for the EVS volume.                              | `"VBD"`                                                  |
+| evs_name              | The EVS volume name.                                             | `"volume-test"`                                          |
+| evs_description       | The EVS volume description.                                      | `"test description"`                                     |
+| evs_size              | The EVS volume size, in GB.                                      | `20`                                                     |
+| evs_multiattach       | Whether the EVS volume is shareable.                             | `false`                                                  |
+| evs_tags              | The key/value pairs to associate with the EVS volume.            | <pre>{<br>  "foo": "bar",<br>  "key": "value"<br>}</pre> |
+
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                       | Description                                                    |
+|----------------------------|----------------------------------------------------------------|
+| evs_volume_id              | The ID of the EVS volume.                                      |
+| evs_attachment             | The EVS volume mount information.                              |
+| evs_wwn                    | The unique identifier used for mounting the EVS volume.        |
+| evs_dedicated_storage_name | The name of the DSS storage pool accommodating the EVS volume. |
+| evs_status                 | The EVS volume status.                                         |

--- a/examples/postpaid-evs-volume/main.tf
+++ b/examples/postpaid-evs-volume/main.tf
@@ -1,0 +1,16 @@
+data "huaweicloud_availability_zones" "test" {}
+
+module "postpaid_evs_volume" {
+  source = "../../modules/evs-volume"
+
+  evs_availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  evs_volume_type       = var.evs_volume_type
+  evs_iops              = var.evs_iops
+  evs_throughput        = var.evs_throughput
+  evs_device_type       = var.evs_device_type
+  evs_name              = var.evs_name
+  evs_description       = var.evs_description
+  evs_size              = var.evs_size
+  evs_multiattach       = var.evs_multiattach
+  evs_tags              = var.evs_tags
+}

--- a/examples/postpaid-evs-volume/outputs.tf
+++ b/examples/postpaid-evs-volume/outputs.tf
@@ -1,0 +1,24 @@
+output "evs_volume_id" {
+  description = "The ID of the EVS volume."
+  value       = module.postpaid_evs_volume.evs_volume_id
+}
+
+output "evs_attachment" {
+  description = "The EVS volume mount information."
+  value       = module.postpaid_evs_volume.evs_attachment
+}
+
+output "evs_wwn" {
+  description = "The unique identifier used for mounting the EVS volume."
+  value       = module.postpaid_evs_volume.evs_wwn
+}
+
+output "evs_dedicated_storage_name" {
+  description = "The name of the DSS storage pool accommodating the EVS volume."
+  value       = module.postpaid_evs_volume.evs_dedicated_storage_name
+}
+
+output "evs_status" {
+  description = "The EVS volume status."
+  value       = module.postpaid_evs_volume.evs_status
+}

--- a/examples/postpaid-evs-volume/variables.json
+++ b/examples/postpaid-evs-volume/variables.json
@@ -1,0 +1,16 @@
+{
+  "charging_mode": "postPaid",
+  "evs_availability_zone": "",
+  "evs_volume_type": "GPSSD2",
+  "evs_iops": 3000,
+  "evs_throughput": 125,
+  "evs_device_type": "VBD",
+  "evs_name": "test-volume-name",
+  "evs_description": "test description",
+  "evs_size": 20,
+  "evs_multiattach": false,
+  "evs_tags": {
+    "foo": "bar",
+    "key": "value"
+  }
+}

--- a/examples/postpaid-evs-volume/variables.tf
+++ b/examples/postpaid-evs-volume/variables.tf
@@ -1,0 +1,80 @@
+######################################################################
+# Configurations of prepaid parameters
+######################################################################
+variable "charging_mode" {
+  description = "The charging mode of the EVS volume."
+
+  type    = string
+  default = null
+}
+
+######################################################################
+# Configurations of EVS volume
+######################################################################
+variable "evs_availability_zone" {
+  description = "The availability zone for the EVS volume."
+
+  type = string
+}
+
+variable "evs_volume_type" {
+  description = "The EVS volume type."
+
+  type = string
+}
+
+variable "evs_iops" {
+  description = "The IOPS(Input/Output Operations Per Second) for the EVS volume."
+
+  type    = number
+  default = null
+}
+
+variable "evs_throughput" {
+  description = "The throughput for the EVS volume."
+
+  type    = number
+  default = null
+}
+
+variable "evs_device_type" {
+  description = "The device type for the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "evs_name" {
+  description = "The EVS volume name."
+
+  type    = string
+  default = null
+}
+
+variable "evs_description" {
+  description = "The EVS volume description."
+
+  type    = string
+  default = null
+}
+
+variable "evs_size" {
+  description = "The EVS volume size, in GB."
+
+  type    = number
+  default = null
+}
+
+variable "evs_multiattach" {
+  description = "Whether the EVS volume is shareable."
+
+  type    = bool
+  default = null
+}
+
+variable "evs_tags" {
+  description = "The key/value pairs to associate with the EVS volume."
+
+  type    = map(string)
+  default = null
+}

--- a/examples/postpaid-evs-volume/versions.tf
+++ b/examples/postpaid-evs-volume/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/evs-volume/README.md
+++ b/modules/evs-volume/README.md
@@ -1,0 +1,115 @@
+# EVS volume management
+
+Manages the EVS volume resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+Please make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages a EVS volume.
+module "evs_volume" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/modules/evs-volume"
+
+  ...
+}
+```
+
+Execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.evs_volume.huaweicloud_evs_volume.test "evs_volume_id"
+
+module.evs_volume.huaweicloud_evs_volume.test: Importing from ID "evs_volume_id"...
+module.evs_volume.huaweicloud_evs_volume.test: Import prepared!
+  Prepared huaweicloud_evs_volume for import
+module.evs_volume.huaweicloud_evs_volume.test: Refreshing state... [id=evs_volume_id]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+### What should we do before deploy this module example
+
+Before manage EVS resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret
+key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK
+information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in
+the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../github/how_to_contribute.md).
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name                        | Type     |
+|-----------------------------|----------|
+| huaweicloud_evs_volume.test | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+
+| Name                     | Description                                                                                                       | Type          | Default | Required |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------|---------------|:-------:|:--------:|
+| evs_availability_zone    | The availability zone for the EVS volume.                                                                         | `string`      |  `""`   |    Y     |
+| evs_volume_type          | The EVS volume type.                                                                                              | `string`      |  `""`   |    Y     |
+| charging_mode            | The charging mode of the EVS volume.                                                                              | `string`      |  `""`   |    N     |
+| period_unit              | The charging period unit of the EVS volume.                                                                       | `string`      |  `""`   |    N     |
+| period                   | The charging period of the EVS volume.                                                                            | `number`      |   `0`   |    N     |
+| auto_renew               | Whether auto-renew is enabled for EVS volume.                                                                     | `string`      |  `""`   |    N     |
+| evs_server_id            | The server ID to which the EVS volume is to be mounted.                                                           | `string`      |  `""`   |    N     |
+| evs_iops                 | The IOPS(Input/Output Operations Per Second) for the EVS volume.                                                  | `number`      |   `0`   |    N     |
+| evs_throughput           | The throughput for the EVS volume.                                                                                | `number`      |   `0`   |    N     |
+| evs_device_type          | The device type for the EVS volume.                                                                               | `string`      | `"VBD"` |    N     |
+| evs_name                 | The EVS volume name.                                                                                              | `string`      |  `""`   |    N     |
+| evs_description          | The EVS volume description.                                                                                       | `string`      |  `""`   |    N     |
+| evs_size                 | The EVS volume size, in GB.                                                                                       | `number`      |   `0`   |    N     |
+| evs_backup_id            | The backup ID from which to create the EVS volume.                                                                | `string`      |  `""`   |    N     |
+| evs_image_id             | The image ID from which to create the EVS volume.                                                                 | `string`      |  `""`   |    N     |
+| evs_snapshot_id          | The snapshot ID from which to create the EVS volume.                                                              | `string`      |  `""`   |    N     |
+| evs_kms_id               | The encryption KMS ID.                                                                                            | `string`      |  `""`   |    N     |
+| evs_multiattach          | Whether the EVS volume is shareable.                                                                              | `bool`        | `false` |    N     |
+| evs_dedicated_storage_id | The ID of the DSS storage pool accommodating the EVS volume.                                                      | `string`      |  `""`   |    N     |
+| evs_tags                 | The key/value pairs to associate with the EVS volume.                                                             | `map(string)` |  `{}`   |    N     |
+| enterprise_project_id    | The enterprise project ID of the disk. For enterprise users, if omitted, default enterprise project will be used. | `string`      |  `""`   |    N     |
+| evs_cascade              | The delete mode of snapshot.                                                                                      | `bool`        | `false` |    N     |
+
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                       | Description                                                    |
+|----------------------------|----------------------------------------------------------------|
+| evs_volume_id              | The ID of the EVS volume.                                      |
+| evs_attachment             | The EVS volume mount information.                              |
+| evs_wwn                    | The unique identifier used for mounting the EVS volume.        |
+| evs_dedicated_storage_name | The name of the DSS storage pool accommodating the EVS volume. |
+| evs_status                 | The EVS volume status.                                         |

--- a/modules/evs-volume/main.tf
+++ b/modules/evs-volume/main.tf
@@ -1,0 +1,28 @@
+resource "huaweicloud_evs_volume" "test" {
+  # prepaid parameters
+  charging_mode = var.charging_mode
+  period_unit   = var.period_unit
+  period        = var.period
+  auto_renew    = var.auto_renew
+
+  // volume parameters
+  availability_zone     = var.evs_availability_zone
+  volume_type           = var.evs_volume_type
+  server_id             = var.evs_server_id
+  iops                  = var.evs_iops
+  throughput            = var.evs_throughput
+  device_type           = var.evs_device_type
+  name                  = var.evs_name
+  description           = var.evs_description
+  size                  = var.evs_size
+  backup_id             = var.evs_backup_id
+  image_id              = var.evs_image_id
+  snapshot_id           = var.evs_snapshot_id
+  kms_id                = var.evs_kms_id
+  multiattach           = var.evs_multiattach
+  dedicated_storage_id  = var.evs_dedicated_storage_id
+  tags                  = var.evs_tags
+  enterprise_project_id = var.enterprise_project_id
+
+  cascade = var.evs_cascade
+}

--- a/modules/evs-volume/outputs.tf
+++ b/modules/evs-volume/outputs.tf
@@ -1,0 +1,30 @@
+output "evs_volume_id" {
+  description = "The ID of the EVS volume."
+  value       = huaweicloud_evs_volume.test.id
+}
+
+output "evs_attachment" {
+  description = "The EVS volume mount information."
+  value = [
+    for evs in huaweicloud_evs_volume.test.attachment : {
+      id          = evs.id
+      instance_id = evs.instance_id
+      device      = evs.device
+    }
+  ]
+}
+
+output "evs_wwn" {
+  description = "The unique identifier used for mounting the EVS volume."
+  value       = huaweicloud_evs_volume.test.wwn
+}
+
+output "evs_dedicated_storage_name" {
+  description = "The name of the DSS storage pool accommodating the EVS volume."
+  value       = huaweicloud_evs_volume.test.dedicated_storage_name
+}
+
+output "evs_status" {
+  description = "The EVS volume status."
+  value       = huaweicloud_evs_volume.test.status
+}

--- a/modules/evs-volume/variables.tf
+++ b/modules/evs-volume/variables.tf
@@ -1,0 +1,157 @@
+######################################################################
+# Configurations of prepaid parameters
+######################################################################
+variable "charging_mode" {
+  description = "The charging mode of the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "period_unit" {
+  description = "The charging period unit of the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "period" {
+  description = "The charging period of the EVS volume."
+
+  type    = number
+  default = null
+}
+
+variable "auto_renew" {
+  description = "Whether auto-renew is enabled for EVS volume."
+
+  type    = string
+  default = null
+}
+
+######################################################################
+# Configurations of EVS volume
+######################################################################
+variable "evs_availability_zone" {
+  description = "The availability zone for the EVS volume."
+
+  type = string
+}
+
+variable "evs_volume_type" {
+  description = "The EVS volume type."
+
+  type = string
+}
+
+variable "evs_server_id" {
+  description = "The server ID to which the EVS volume is to be mounted."
+
+  type    = string
+  default = null
+}
+
+variable "evs_iops" {
+  description = "The IOPS(Input/Output Operations Per Second) for the EVS volume."
+
+  type    = number
+  default = null
+}
+
+variable "evs_throughput" {
+  description = "The throughput for the EVS volume."
+
+  type    = number
+  default = null
+}
+
+variable "evs_device_type" {
+  description = "The device type for the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "evs_name" {
+  description = "The EVS volume name."
+
+  type    = string
+  default = null
+}
+
+variable "evs_description" {
+  description = "The EVS volume description."
+
+  type    = string
+  default = null
+}
+
+variable "evs_size" {
+  description = "The EVS volume size, in GB."
+
+  type    = number
+  default = null
+}
+
+variable "evs_backup_id" {
+  description = "The backup ID from which to create the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "evs_image_id" {
+  description = "The image ID from which to create the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "evs_snapshot_id" {
+  description = "The snapshot ID from which to create the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "evs_kms_id" {
+  description = "The encryption KMS ID."
+
+  type    = string
+  default = null
+}
+
+variable "evs_multiattach" {
+  description = "Whether the EVS volume is shareable."
+
+  type    = bool
+  default = null
+}
+
+variable "evs_dedicated_storage_id" {
+  description = "The ID of the DSS storage pool accommodating the EVS volume."
+
+  type    = string
+  default = null
+}
+
+variable "evs_tags" {
+  description = "The key/value pairs to associate with the EVS volume."
+
+  type    = map(string)
+  default = null
+}
+
+variable "enterprise_project_id" {
+  description = "The enterprise project ID of the disk. For enterprise users, if omitted, default enterprise project will be used."
+
+  type    = string
+  default = null
+}
+
+variable "evs_cascade" {
+  description = "The delete mode of snapshot."
+
+  type    = bool
+  default = null
+}

--- a/modules/evs-volume/versions.tf
+++ b/modules/evs-volume/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
Add postpaid evs volume modules.

## test running module
```
terraform apply -var-file=variables.json
data.huaweicloud_availability_zones.test: Reading...
data.huaweicloud_availability_zones.test: Read complete after 0s [id=74326821]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.postpaid_evs_volume.huaweicloud_evs_volume.test will be created
  + resource "huaweicloud_evs_volume" "test" {
      + attachment             = (known after apply)
      + availability_zone      = "cn-north-4a"
      + cascade                = false
      + charging_mode          = (known after apply)
      + dedicated_storage_name = (known after apply)
      + description            = "test description"
      + device_type            = "VBD"
      + enterprise_project_id  = (known after apply)
      + id                     = (known after apply)
      + iops                   = 3000
      + multiattach            = false
      + name                   = "test-volume-name"
      + region                 = (known after apply)
      + size                   = 20
      + status                 = (known after apply)
      + tags                   = {
          + "foo" = "bar"
          + "key" = "value"
        }
      + throughput             = 125
      + volume_type            = "GPSSD2"
      + wwn                    = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + evs_attachment             = (known after apply)
  + evs_dedicated_storage_name = (known after apply)
  + evs_status                 = (known after apply)
  + evs_volume_id              = (known after apply)
  + evs_wwn                    = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.postpaid_evs_volume.huaweicloud_evs_volume.test: Creating...
module.postpaid_evs_volume.huaweicloud_evs_volume.test: Still creating... [10s elapsed]
module.postpaid_evs_volume.huaweicloud_evs_volume.test: Still creating... [20s elapsed]
module.postpaid_evs_volume.huaweicloud_evs_volume.test: Creation complete after 25s [id=XXX]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

evs_attachment = []
evs_dedicated_storage_name = ""
evs_status = "available"
evs_volume_id = "XXX"
evs_wwn = "XXX"
```

## test destroying module
```
terraform destroy -var-file=variables.json
data.huaweicloud_availability_zones.test: Reading...
data.huaweicloud_availability_zones.test: Read complete after 1s [id=74326821]
module.postpaid_evs_volume.huaweicloud_evs_volume.test: Refreshing state... [id=3ddbfbfa-7464-44c3-84e2-a6d8985d4640]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # module.postpaid_evs_volume.huaweicloud_evs_volume.test will be destroyed
  - resource "huaweicloud_evs_volume" "test" {
      - attachment             = [] -> null
      - availability_zone      = "cn-north-4a" -> null
      - cascade                = false -> null
      - description            = "test description" -> null
      - device_type            = "VBD" -> null
      - enterprise_project_id  = "0" -> null
      - id                     = "XXX" -> null
      - iops                   = 3000 -> null
      - multiattach            = false -> null
      - name                   = "test-volume-name" -> null
      - region                 = "cn-north-4" -> null
      - size                   = 20 -> null
      - status                 = "available" -> null
      - tags                   = {
          - "foo" = "bar"
          - "key" = "value"
        } -> null
      - throughput             = 125 -> null
      - volume_type            = "GPSSD2" -> null
      - wwn                    = "XXX" -> null
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - evs_attachment             = [] -> null
  - evs_dedicated_storage_name = "" -> null
  - evs_status                 = "available" -> null
  - evs_volume_id              = "XXX" -> null
  - evs_wwn                    = "XXX" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

module.postpaid_evs_volume.huaweicloud_evs_volume.test: Destroying... [id=XXX]
module.postpaid_evs_volume.huaweicloud_evs_volume.test: Still destroying... [id=XXX, 10s elapsed]
module.postpaid_evs_volume.huaweicloud_evs_volume.test: Destruction complete after 11s

Destroy complete! Resources: 1 destroyed.
```