### PR TITLE
feat(script): add new evs volume module script

### DIFF
--- a/.github/how_to_contribute.md
+++ b/.github/how_to_contribute.md
@@ -13,7 +13,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## Pull Request Process
 
-1. Update README.md with the details of the changes, including example hcl blocks and [example files](./examples), if
+1. Update README.md with the details of the changes, including example hcl blocks and [example files](../examples), if
    appropriate.
 2. Once all open comments and all checklist items are resolved, your contributions will be merged! The merged PR will be
    included in the next release. The terraform-huaweicloud-evs maintainers are responsible for updating the CHANGELOG when they

--- a/examples/evs-postpaid-volume/README.md
+++ b/examples/evs-postpaid-volume/README.md
@@ -1,0 +1,64 @@
+# Postpaid EVS volume example
+
+Configuration in this directory creates a postpaid EVS volume.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+
+| Name       | Source                                                         | Version |
+|------------|----------------------------------------------------------------|---------|
+| evs_volume | [../../modules/evs-volume](../../modules/evs-volume/README.md) | N/A     |
+
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name                                     | Type        |
+|------------------------------------------|-------------|
+| huaweicloud_evs_volume.this              | resource    |
+| data.huaweicloud_availability_zones.this | data-source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                     | Description                                                     | Value                                                 |
+|--------------------------|-----------------------------------------------------------------|-------------------------------------------------------|
+| volume_availability_zone | The availability zone for the EVS volume                        | `"cn-north-4"`                                        |
+| volume_volume_type       | The EVS volume type                                             | `"GPSSD2"`                                            |
+| volume_iops              | The IOPS(Input/Output Operations Per Second) for the EVS volume | `3000`                                                |
+| volume_throughput        | The throughput for the EVS volume                               | `125`                                                 |
+| volume_device_type       | The device type for the EVS volume                              | `"VBD"`                                               |
+| volume_name              | The EVS volume name                                             | `"volume-test"`                                       |
+| volume_description       | The EVS volume description                                      | `"test description"`                                  |
+| volume_size              | The EVS volume size, in GB                                      | `20`                                                  |
+| volume_multiattach       | Whether the EVS volume is shareable                             | `false`                                               |
+| volume_tags              | The key/value pairs to associate with the EVS volume            | <pre>{<br>  foo = "bar"<br>  key = "value"<br>}</pre> |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name             | Description                                            |
+|------------------|--------------------------------------------------------|
+| volume_volume_id | The ID of the EVS volume                               |
+| volume_wwn       | The unique identifier used for mounting the EVS volume |
+| volume_status    | The EVS volume status                                  |

--- a/examples/evs-postpaid-volume/main.tf
+++ b/examples/evs-postpaid-volume/main.tf
@@ -1,0 +1,16 @@
+data "huaweicloud_availability_zones" "this" {}
+
+module "evs_postpaid_volume" {
+  source = "../../modules/evs-volume"
+
+  volume_availability_zone = var.volume_availability_zone != null ? var.volume_availability_zone : try(data.huaweicloud_availability_zones.this.names[0], "")
+  volume_volume_type       = var.volume_volume_type
+  volume_iops              = var.volume_iops
+  volume_throughput        = var.volume_throughput
+  volume_device_type       = var.volume_device_type
+  volume_name              = var.volume_name
+  volume_description       = var.volume_description
+  volume_size              = var.volume_size
+  volume_multiattach       = var.volume_multiattach
+  volume_tags              = var.volume_tags
+}

--- a/examples/evs-postpaid-volume/outputs.tf
+++ b/examples/evs-postpaid-volume/outputs.tf
@@ -1,0 +1,14 @@
+output "volume_volume_id" {
+  description = "The ID of the EVS volume."
+  value       = module.evs_postpaid_volume.volume_volume_id
+}
+
+output "volume_wwn" {
+  description = "The unique identifier used for mounting the EVS volume."
+  value       = module.evs_postpaid_volume.volume_wwn
+}
+
+output "volume_status" {
+  description = "The EVS volume status."
+  value       = module.evs_postpaid_volume.volume_status
+}

--- a/examples/evs-postpaid-volume/variables.json
+++ b/examples/evs-postpaid-volume/variables.json
@@ -1,0 +1,14 @@
+{
+  "volume_volume_type": "GPSSD2",
+  "volume_iops": 3000,
+  "volume_throughput": 125,
+  "volume_device_type": "VBD",
+  "volume_name": "test-volume-name",
+  "volume_description": "test description",
+  "volume_size": 20,
+  "volume_multiattach": false,
+  "volume_tags": {
+    "foo": "bar",
+    "key": "value"
+  }
+}

--- a/examples/evs-postpaid-volume/variables.tf
+++ b/examples/evs-postpaid-volume/variables.tf
@@ -1,0 +1,62 @@
+######################################################################
+# Configurations of EVS volume
+######################################################################
+variable "volume_availability_zone" {
+  type        = string
+  description = "The availability zone for the EVS volume."
+  default     = null
+}
+
+variable "volume_volume_type" {
+  type        = string
+  description = "The EVS volume type."
+  default     = null
+}
+
+variable "volume_iops" {
+  type        = number
+  description = "The IOPS(Input/Output Operations Per Second) for the EVS volume."
+  default     = null
+}
+
+variable "volume_throughput" {
+  type        = number
+  description = "The throughput for the EVS volume."
+  default     = null
+}
+
+variable "volume_device_type" {
+  type        = string
+  description = "The device type for the EVS volume."
+  default     = null
+}
+
+variable "volume_name" {
+  type        = string
+  description = "The EVS volume name."
+  default     = null
+}
+
+variable "volume_description" {
+  type        = string
+  description = "The EVS volume description."
+  default     = null
+}
+
+variable "volume_size" {
+  type        = number
+  description = "The EVS volume size, in GB."
+  default     = null
+}
+
+variable "volume_multiattach" {
+  type        = bool
+  description = "Whether the EVS volume is shareable."
+  default     = null
+}
+
+variable "volume_tags" {
+  type        = map(string)
+  description = "The key/value pairs to associate with the EVS volume."
+  default     = null
+}

--- a/examples/evs-postpaid-volume/versions.tf
+++ b/examples/evs-postpaid-volume/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/evs-volume/README.md
+++ b/modules/evs-volume/README.md
@@ -1,0 +1,113 @@
+# EVS volume management
+
+Manages the EVS volume resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+Please make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages a EVS volume.
+module "evs_volume" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/modules/evs-volume"
+
+  ...
+}
+```
+
+Execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.evs_volume.huaweicloud_evs_volume.this[0] "evs_volume_id"
+
+module.evs_volume.huaweicloud_evs_volume.this[0]: Importing from ID "evs_volume_id"...
+module.evs_volume.huaweicloud_evs_volume.this[0]: Import prepared!
+  Prepared huaweicloud_evs_volume for import
+module.evs_volume.huaweicloud_evs_volume.this[0]: Refreshing state... [id=evs_volume_id]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+### What should we do before deploy this module example
+
+Before manage EVS resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret
+key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK
+information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in
+the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../.github/how_to_contribute.md).
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name                        | Type     |
+|-----------------------------|----------|
+| huaweicloud_evs_volume.this | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                         | Description                                                                                                      | Type                     | Default |                     Required                      |
+|------------------------------|------------------------------------------------------------------------------------------------------------------|--------------------------|:-------:|:-------------------------------------------------:|
+| volume_charging_mode         | The charging mode of the EVS volume                                                                              | `string`                 | `null`  |                         N                         |
+| volume_period_unit           | The charging period unit of the EVS volume                                                                       | `string`                 | `null`  |                         N                         |
+| volume_period                | The charging period of the EVS volume                                                                            | `number`                 | `null`  |                         N                         |
+| volume_auto_renew            | Whether auto-renew is enabled for EVS volume                                                                     | `string`                 | `null`  |                         N                         |
+| is_volume_create             | Controls whether the EVS volumes should be created (it affects all EVS related resources under this module)      | `bool`                   | `true`  |                         N                         |
+| volume_availability_zone     | The availability zone for the EVS volume                                                                         | `string`                 | `null`  | Y (Unless is_volume_create is specified as false) |
+| volume_volume_type           | The EVS volume type                                                                                              | `string`                 | `null`  | Y (Unless is_volume_create is specified as false) |
+| volume_server_id             | The server ID to which the EVS volume is to be mounted                                                           | `string`                 | `null`  |                         N                         |
+| volume_iops                  | The IOPS(Input/Output Operations Per Second) for the EVS volume                                                  | `number`                 | `null`  |                         N                         |
+| volume_throughput            | The throughput for the EVS volume                                                                                | `number`                 | `null`  |                         N                         |
+| volume_device_type           | The device type for the EVS volume                                                                               | `string`                 | `null`  |                         N                         |
+| volume_name                  | The EVS volume name                                                                                              | `string`                 | `null`  |                         N                         |
+| volume_description           | The EVS volume description                                                                                       | `string`                 | `null`  |                         N                         |
+| volume_size                  | The EVS volume size, in GB.                                                                                      | `number`                 | `null`  |                         N                         |
+| volume_backup_id             | The backup ID from which to create the EVS volume                                                                | `string`                 | `null`  |                         N                         |
+| volume_image_id              | The image ID from which to create the EVS volume                                                                 | `string`                 | `null`  |                         N                         |
+| volume_snapshot_id           | The snapshot ID from which to create the EVS volume                                                              | `string`                 | `null`  |                         N                         |
+| volume_kms_id                | The encryption KMS ID                                                                                            | `string`                 | `null`  |                         N                         |
+| volume_multiattach           | Whether the EVS volume is shareable                                                                              | `bool`                   | `null`  |                         N                         |
+| volume_dedicated_storage_id  | The ID of the DSS storage pool accommodating the EVS volume                                                      | `string`                 | `null`  |                         N                         |
+| volume_tags                  | The key/value pairs to associate with the EVS volume                                                             | `<pre>map(string)</pre>` | `null`  |                         N                         |
+| volume_enterprise_project_id | The enterprise project ID of the disk. For enterprise users, if omitted, default enterprise project will be used | `string`                 | `null`  |                         N                         |
+| volume_cascade               | The delete mode of snapshot                                                                                      | `bool`                   | `null`  |                         N                         |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                          | Description                                                   |
+|-------------------------------|---------------------------------------------------------------|
+| volume_volume_id              | The ID of the EVS volume                                      |
+| volume_wwn                    | The unique identifier used for mounting the EVS volume        |
+| volume_dedicated_storage_name | The name of the DSS storage pool accommodating the EVS volume |
+| volume_status                 | The EVS volume status                                         |

--- a/modules/evs-volume/main.tf
+++ b/modules/evs-volume/main.tf
@@ -1,0 +1,30 @@
+resource "huaweicloud_evs_volume" "this" {
+  count = var.is_volume_create ? 1 : 0
+
+  # prepaid parameters
+  charging_mode = var.volume_charging_mode
+  period_unit   = var.volume_period_unit
+  period        = var.volume_period
+  auto_renew    = var.volume_auto_renew
+
+  # volume parameters
+  availability_zone     = var.volume_availability_zone
+  volume_type           = var.volume_volume_type
+  server_id             = var.volume_server_id
+  iops                  = var.volume_iops
+  throughput            = var.volume_throughput
+  device_type           = var.volume_device_type
+  name                  = var.volume_name
+  description           = var.volume_description
+  size                  = var.volume_size
+  backup_id             = var.volume_backup_id
+  image_id              = var.volume_image_id
+  snapshot_id           = var.volume_snapshot_id
+  kms_id                = var.volume_kms_id
+  multiattach           = var.volume_multiattach
+  dedicated_storage_id  = var.volume_dedicated_storage_id
+  tags                  = var.volume_tags
+  enterprise_project_id = var.volume_enterprise_project_id
+
+  cascade = var.volume_cascade
+}

--- a/modules/evs-volume/outputs.tf
+++ b/modules/evs-volume/outputs.tf
@@ -1,0 +1,19 @@
+output "volume_volume_id" {
+  description = "The ID of the EVS volume."
+  value       = try(huaweicloud_evs_volume.this[0].id, "")
+}
+
+output "volume_wwn" {
+  description = "The unique identifier used for mounting the EVS volume."
+  value       = try(huaweicloud_evs_volume.this[0].wwn, "")
+}
+
+output "volume_dedicated_storage_name" {
+  description = "The name of the DSS storage pool accommodating the EVS volume."
+  value       = try(huaweicloud_evs_volume.this[0].dedicated_storage_name, "")
+}
+
+output "volume_status" {
+  description = "The EVS volume status."
+  value       = try(huaweicloud_evs_volume.this[0].status, "")
+}

--- a/modules/evs-volume/variables.tf
+++ b/modules/evs-volume/variables.tf
@@ -1,0 +1,146 @@
+######################################################################
+# Configurations of prepaid parameters
+######################################################################
+
+variable "volume_charging_mode" {
+  type        = string
+  description = "The charging mode of the EVS volume."
+  default     = null
+}
+
+variable "volume_period_unit" {
+  type        = string
+  description = "The charging period unit of the EVS volume."
+  default     = null
+}
+
+variable "volume_period" {
+  type        = number
+  description = "The charging period of the EVS volume."
+  default     = null
+}
+
+variable "volume_auto_renew" {
+  type        = string
+  description = "Whether auto-renew is enabled for EVS volume."
+  default     = null
+}
+
+######################################################################
+# Configurations of EVS volume
+######################################################################
+
+variable "is_volume_create" {
+  type        = bool
+  description = "Controls whether the EVS volumes should be created (it affects all EVS related resources under this module)"
+  default     = true
+  nullable    = false
+}
+
+variable "volume_availability_zone" {
+  type        = string
+  description = "The availability zone for the EVS volume."
+  default     = null
+}
+
+variable "volume_volume_type" {
+  type        = string
+  description = "The EVS volume type."
+  default     = null
+}
+
+variable "volume_server_id" {
+  type        = string
+  description = "The server ID to which the EVS volume is to be mounted."
+  default     = null
+}
+
+variable "volume_iops" {
+  type        = number
+  description = "The IOPS(Input/Output Operations Per Second) for the EVS volume."
+  default     = null
+}
+
+variable "volume_throughput" {
+  type        = number
+  description = "The throughput for the EVS volume."
+  default     = null
+}
+
+variable "volume_device_type" {
+  type        = string
+  description = "The device type for the EVS volume."
+  default     = null
+}
+
+variable "volume_name" {
+  type        = string
+  description = "The EVS volume name."
+  default     = null
+}
+
+variable "volume_description" {
+  type        = string
+  description = "The EVS volume description."
+  default     = null
+}
+
+variable "volume_size" {
+  type        = number
+  description = "The EVS volume size, in GB."
+  default     = null
+}
+
+variable "volume_backup_id" {
+  type        = string
+  description = "The backup ID from which to create the EVS volume."
+  default     = null
+}
+
+variable "volume_image_id" {
+  type        = string
+  description = "The image ID from which to create the EVS volume."
+  default     = null
+}
+
+variable "volume_snapshot_id" {
+  type        = string
+  description = "The snapshot ID from which to create the EVS volume."
+  default     = null
+}
+
+variable "volume_kms_id" {
+  type        = string
+  description = "The encryption KMS ID."
+  default     = null
+}
+
+variable "volume_multiattach" {
+  type        = bool
+  description = "Whether the EVS volume is shareable."
+  default     = null
+}
+
+variable "volume_dedicated_storage_id" {
+  type        = string
+  description = "The ID of the DSS storage pool accommodating the EVS volume."
+  default     = null
+}
+
+variable "volume_tags" {
+  type        = map(string)
+  description = "The key/value pairs to associate with the EVS volume."
+  default     = null
+}
+
+variable "volume_enterprise_project_id" {
+  type        = string
+  description = "The enterprise project ID of the disk. For enterprise users, if omitted, default enterprise project will be used."
+  default     = null
+}
+
+variable "volume_cascade" {
+  type        = bool
+  description = "The delete mode of snapshot."
+  default     = null
+}

--- a/modules/evs-volume/versions.tf
+++ b/modules/evs-volume/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
Add new evs volume module script.

## test running module
```
terraform apply -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.evs_postpaid_volume.huaweicloud_evs_volume.this[0] will be created
  + resource "huaweicloud_evs_volume" "this" {
      + attachment             = (known after apply)
      + availability_zone      = "cn-north-4a"
      + cascade                = false
      + charging_mode          = (known after apply)
      + dedicated_storage_name = (known after apply)
      + description            = "test description"
      + device_type            = "VBD"
      + enterprise_project_id  = (known after apply)
      + id                     = (known after apply)
      + iops                   = 3000
      + multiattach            = false
      + name                   = "test-volume-name"
      + region                 = (known after apply)
      + size                   = 20
      + status                 = (known after apply)
      + tags                   = {
          + "foo" = "bar"
          + "key" = "value"
        }
      + throughput             = 125
      + volume_type            = "GPSSD2"
      + wwn                    = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + evs_status    = (known after apply)
  + evs_volume_id = (known after apply)
  + evs_wwn       = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Creating...
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still creating... [10s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still creating... [20s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Creation complete after 25s [id=5dc57715-ed9c-469e-b58f-af3b0eebc8c8]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

evs_status = "available"
evs_volume_id = "5dc57715-ed9c-469e-b58f-af3b0eebc8c8"
evs_wwn = "688860311963244010000000020415a0"
```


## test destroying module
```
terraform destroy -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Refreshing state... [id=5dc57715-ed9c-469e-b58f-af3b0eebc8c8]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # module.evs_postpaid_volume.huaweicloud_evs_volume.this[0] will be destroyed
  - resource "huaweicloud_evs_volume" "this" {
      - attachment             = [] -> null
      - availability_zone      = "cn-north-4a" -> null
      - cascade                = false -> null
      - description            = "test description" -> null
      - device_type            = "VBD" -> null
      - enterprise_project_id  = "0" -> null
      - id                     = "5dc57715-ed9c-469e-b58f-af3b0eebc8c8" -> null
      - iops                   = 3000 -> null
      - multiattach            = false -> null
      - name                   = "test-volume-name" -> null
      - region                 = "cn-north-4" -> null
      - size                   = 20 -> null
      - status                 = "available" -> null
      - tags                   = {
          - "foo" = "bar"
          - "key" = "value"
        } -> null
      - throughput             = 125 -> null
      - volume_type            = "GPSSD2" -> null
      - wwn                    = "688860311963244010000000020415a0" -> null
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - evs_status    = "available" -> null
  - evs_volume_id = "5dc57715-ed9c-469e-b58f-af3b0eebc8c8" -> null
  - evs_wwn       = "688860311963244010000000020415a0" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Destroying... [id=5dc57715-ed9c-469e-b58f-af3b0eebc8c8]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still destroying... [id=5dc57715-ed9c-469e-b58f-af3b0eebc8c8, 10s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Destruction complete after 11s

Destroy complete! Resources: 1 destroyed.
```

