### PR TITLE
feat(script): add new evs snapshot module script

### DIFF
--- a/examples/evs-snapshot/README.md
+++ b/examples/evs-snapshot/README.md
@@ -1,0 +1,68 @@
+# EVS snapshot example
+
+Configuration in this directory creates an EVS snapshot.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name         | Source                                                             | Version |
+|--------------|--------------------------------------------------------------------|---------|
+| evs_volume   | [../../modules/evs-volume](../../modules/evs-volume/README.md)     | N/A     |
+| evs_snapshot | [../../modules/evs-snapshot](../../modules/evs-snapshot/README.md) | N/A     |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name                                     | Type        |
+|------------------------------------------|-------------|
+| huaweicloud_evs_snapshot.this            | resource    |
+| huaweicloud_evs_volume.this              | resource    |
+| data.huaweicloud_availability_zones.this | data-source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                     | Description                                                     | Value                                                 |
+|--------------------------|-----------------------------------------------------------------|-------------------------------------------------------|
+| volume_availability_zone | The availability zone for the EVS volume                        | `"cn-north-4a"`                                       |
+| volume_type              | The EVS volume type                                             | `"GPSSD2"`                                            |
+| volume_iops              | The IOPS(Input/Output Operations Per Second) for the EVS volume | `3000`                                                |
+| volume_throughput        | The throughput for the EVS volume                               | `125`                                                 |
+| volume_device_type       | The device type for the EVS volume                              | `"VBD"`                                               |
+| volume_name              | The EVS volume name                                             | `"volume-test"`                                       |
+| volume_description       | The EVS volume description                                      | `"test description"`                                  |
+| volume_size              | The EVS volume size, in GB                                      | `20`                                                  |
+| volume_multiattach       | Whether the EVS volume is shareable                             | `false`                                               |
+| volume_tags              | The key/value pairs to associate with the EVS volume            | <pre>{<br>  foo = "bar"<br>  key = "value"<br>}</pre> |
+| snapshot_name            | The name of the snapshot                                        | `"test-snapshot-name"`                                |
+| snapshot_metadata        | The user-defined metadata key-value pair                        | <pre>{<br>  meta_key = "meta_value"<br>}</pre>        |
+| snapshot_description     | The description of the snapshot                                 | `"test description"`                                  |
+| snapshot_force           | The flag for forcibly creating a snapshot                       | `true`                                                |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name            | Description                    |
+|-----------------|--------------------------------|
+| snapshot_id     | The ID of the snapshot         |
+| snapshot_status | The status of the snapshot     |
+| snapshot_size   | The size of the snapshot in GB |

--- a/examples/evs-snapshot/main.tf
+++ b/examples/evs-snapshot/main.tf
@@ -1,0 +1,27 @@
+data "huaweicloud_availability_zones" "this" {}
+
+module "evs_postpaid_volume" {
+  source = "../../modules/evs-volume"
+
+  volume_availability_zone = var.volume_availability_zone != null ? var.volume_availability_zone : try(data.huaweicloud_availability_zones.this.names[0], "")
+  volume_type              = var.volume_type
+  volume_iops              = var.volume_iops
+  volume_throughput        = var.volume_throughput
+  volume_device_type       = var.volume_device_type
+  volume_name              = var.volume_name
+  volume_description       = var.volume_description
+  volume_size              = var.volume_size
+  volume_multiattach       = var.volume_multiattach
+  volume_tags              = var.volume_tags
+}
+
+module "evs_snapshot" {
+  source = "../../modules/evs-snapshot"
+
+  snapshot_volume_id   = module.evs_postpaid_volume.volume_id
+  snapshot_name        = var.snapshot_name
+  snapshot_metadata    = var.snapshot_metadata
+  snapshot_description = var.snapshot_description
+  snapshot_force       = var.snapshot_force
+}
+

--- a/examples/evs-snapshot/outputs.tf
+++ b/examples/evs-snapshot/outputs.tf
@@ -1,0 +1,14 @@
+output "snapshot_id" {
+  description = "The ID of the snapshot"
+  value       = module.evs_snapshot.snapshot_id
+}
+
+output "snapshot_status" {
+  description = "The status of the snapshot"
+  value       = module.evs_snapshot.snapshot_status
+}
+
+output "snapshot_size" {
+  description = "The size of the snapshot in GB"
+  value       = module.evs_snapshot.snapshot_size
+}

--- a/examples/evs-snapshot/variables.json
+++ b/examples/evs-snapshot/variables.json
@@ -1,0 +1,20 @@
+{
+  "volume_type": "GPSSD2",
+  "volume_iops": 3000,
+  "volume_throughput": 125,
+  "volume_device_type": "VBD",
+  "volume_name": "test-volume-name",
+  "volume_description": "test description",
+  "volume_size": 20,
+  "volume_multiattach": false,
+  "volume_tags": {
+    "foo": "bar",
+    "key": "value"
+  },
+  "snapshot_name": "test-snapshot-name",
+  "snapshot_metadata": {
+    "meta_key": "meta_value"
+  },
+  "snapshot_description": "test description",
+  "snapshot_force": true
+}

--- a/examples/evs-snapshot/variables.tf
+++ b/examples/evs-snapshot/variables.tf
@@ -1,0 +1,89 @@
+######################################################################
+# Configurations of EVS volume
+######################################################################
+variable "volume_availability_zone" {
+  type        = string
+  description = "The availability zone for the EVS volume"
+  default     = null
+}
+
+variable "volume_type" {
+  type        = string
+  description = "The EVS volume type"
+  default     = null
+}
+
+variable "volume_iops" {
+  type        = number
+  description = "The IOPS(Input/Output Operations Per Second) for the EVS volume"
+  default     = null
+}
+
+variable "volume_throughput" {
+  type        = number
+  description = "The throughput for the EVS volume"
+  default     = null
+}
+
+variable "volume_device_type" {
+  type        = string
+  description = "The device type for the EVS volume"
+  default     = null
+}
+
+variable "volume_name" {
+  type        = string
+  description = "The EVS volume name"
+  default     = null
+}
+
+variable "volume_description" {
+  type        = string
+  description = "The EVS volume description"
+  default     = null
+}
+
+variable "volume_size" {
+  type        = number
+  description = "The EVS volume size, in GB"
+  default     = null
+}
+
+variable "volume_multiattach" {
+  type        = bool
+  description = "Whether the EVS volume is shareable"
+  default     = null
+}
+
+variable "volume_tags" {
+  type        = map(string)
+  description = "The key/value pairs to associate with the EVS volume"
+  default     = null
+}
+
+######################################################################
+# Configurations of EVS snapshot
+######################################################################
+variable "snapshot_name" {
+  type        = string
+  description = "The name of the snapshot"
+  default     = null
+}
+
+variable "snapshot_metadata" {
+  type        = map(string)
+  description = "The user-defined metadata key-value pair"
+  default     = null
+}
+
+variable "snapshot_description" {
+  type        = string
+  description = "The description of the snapshot"
+  default     = null
+}
+
+variable "snapshot_force" {
+  type        = bool
+  description = "The flag for forcibly creating a snapshot"
+  default     = null
+}

--- a/examples/evs-snapshot/versions.tf
+++ b/examples/evs-snapshot/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/evs-snapshot/README.md
+++ b/modules/evs-snapshot/README.md
@@ -1,0 +1,95 @@
+# EVS snapshot management
+
+Manages the EVS snapshot resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+Please make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages an EVS snapshot.
+module "evs_snapshot" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/modules/evs-snapshot"
+
+  ...
+}
+```
+
+Execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.evs_snapshot.huaweicloud_evs_snapshot.this[0] "snapshot_id"
+
+module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Importing from ID "snapshot_id"...
+module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Import prepared!
+  Prepared huaweicloud_evs_snapshot for import
+module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Refreshing state... [id=snapshot_id]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+### What should we do before deploy this module example
+
+Before manage EVS resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret
+key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK
+information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in
+the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../.github/how_to_contribute.md).
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name                          | Type     |
+|-------------------------------|----------|
+| huaweicloud_evs_snapshot.this | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                 | Description                                                                                                   | Type                     | Default |                      Required                       |
+|----------------------|---------------------------------------------------------------------------------------------------------------|--------------------------|:-------:|:---------------------------------------------------:|
+| is_snapshot_create   | Controls whether the EVS snapshots should be created (it affects all EVS related resources under this module) | `bool`                   | `true`  |                          N                          |
+| snapshot_volume_id   | The ID of the snapshot's source EVS volume                                                                    | `string`                 | `null`  | Y (Unless is_snapshot_create is specified as false) |
+| snapshot_name        | The name of the snapshot                                                                                      | `string`                 | `null`  | Y (Unless is_snapshot_create is specified as false) |
+| snapshot_metadata    | The user-defined metadata key-value pair                                                                      | `<pre>map(string)</pre>` | `null`  |                          N                          |
+| snapshot_description | The description of the snapshot                                                                               | `string`                 | `null`  |                          N                          |
+| snapshot_force       | The flag for forcibly creating a snapshot                                                                     | `bool`                   | `null`  |                          N                          |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name            | Description                    |
+|-----------------|--------------------------------|
+| snapshot_id     | The ID of the snapshot         |
+| snapshot_status | The status of the snapshot     |
+| snapshot_size   | The size of the snapshot in GB |

--- a/modules/evs-snapshot/main.tf
+++ b/modules/evs-snapshot/main.tf
@@ -1,0 +1,9 @@
+resource "huaweicloud_evs_snapshot" "this" {
+  count = var.is_snapshot_create ? 1 : 0
+
+  volume_id   = var.snapshot_volume_id
+  name        = var.snapshot_name
+  metadata    = var.snapshot_metadata
+  description = var.snapshot_description
+  force       = var.snapshot_force
+}

--- a/modules/evs-snapshot/outputs.tf
+++ b/modules/evs-snapshot/outputs.tf
@@ -1,0 +1,14 @@
+output "snapshot_id" {
+  description = "The ID of the snapshot"
+  value       = try(huaweicloud_evs_snapshot.this[0].id, "")
+}
+
+output "snapshot_status" {
+  description = "The status of the snapshot"
+  value       = try(huaweicloud_evs_snapshot.this[0].status, "")
+}
+
+output "snapshot_size" {
+  description = "The size of the snapshot in GB"
+  value       = try(huaweicloud_evs_snapshot.this[0].size, 0)
+}

--- a/modules/evs-snapshot/variables.tf
+++ b/modules/evs-snapshot/variables.tf
@@ -1,0 +1,40 @@
+######################################################################
+# Configurations of EVS snapshot
+######################################################################
+
+variable "is_snapshot_create" {
+  type        = bool
+  description = "Controls whether the EVS snapshots should be created (it affects all EVS related resources under this module)"
+  default     = true
+  nullable    = false
+}
+
+variable "snapshot_volume_id" {
+  type        = string
+  description = "The ID of the snapshot's source EVS volume"
+  default     = null
+}
+
+variable "snapshot_name" {
+  type        = string
+  description = "The name of the snapshot"
+  default     = null
+}
+
+variable "snapshot_metadata" {
+  type        = map(string)
+  description = "The user-defined metadata key-value pair"
+  default     = null
+}
+
+variable "snapshot_description" {
+  type        = string
+  description = "The description of the snapshot"
+  default     = null
+}
+
+variable "snapshot_force" {
+  type        = bool
+  description = "The flag for forcibly creating a snapshot"
+  default     = null
+}

--- a/modules/evs-snapshot/versions.tf
+++ b/modules/evs-snapshot/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
# Add new evs snapshot module script.
## test running snapshot module
```
terraform apply -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 1s [id=74326821]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.evs_postpaid_volume.huaweicloud_evs_volume.this[0] will be created
  + resource "huaweicloud_evs_volume" "this" {
      + attachment             = (known after apply)
      + availability_zone      = "cn-north-4a"
      + cascade                = false
      + charging_mode          = (known after apply)
      + dedicated_storage_name = (known after apply)
      + description            = "test description"
      + device_type            = "VBD"
      + enterprise_project_id  = (known after apply)
      + id                     = (known after apply)
      + iops                   = 3000
      + multiattach            = false
      + name                   = "test-volume-name"
      + region                 = (known after apply)
      + size                   = 20
      + status                 = (known after apply)
      + tags                   = {
          + "foo" = "bar"
          + "key" = "value"
        }
      + throughput             = 125
      + volume_type            = "GPSSD2"
      + wwn                    = (known after apply)
    }

  # module.evs_snapshot.huaweicloud_evs_snapshot.this[0] will be created
  + resource "huaweicloud_evs_snapshot" "this" {
      + description = "test description"
      + force       = true
      + id          = (known after apply)
      + metadata    = {
          + "meta_key" = "meta_value"
        }
      + name        = "test-snapshot-name"
      + region      = (known after apply)
      + size        = (known after apply)
      + status      = (known after apply)
      + volume_id   = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + snapshot_id     = (known after apply)
  + snapshot_size   = (known after apply)
  + snapshot_status = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Creating...
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still creating... [10s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still creating... [20s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Creation complete after 25s [id=b72e2ca5-6fd6-4392-89e5-b41bb5e23139]
module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Creating...
module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Creation complete after 6s [id=7321e434-2777-4b83-9a5d-07454314e451]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

snapshot_id = "7321e434-2777-4b83-9a5d-07454314e451"
snapshot_size = 20
snapshot_status = "available"
```

## test destroying snapshot module
```
terraform destroy -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Refreshing state... [id=b72e2ca5-6fd6-4392-89e5-b41bb5e23139]
module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Refreshing state... [id=7321e434-2777-4b83-9a5d-07454314e451]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # module.evs_postpaid_volume.huaweicloud_evs_volume.this[0] will be destroyed
  - resource "huaweicloud_evs_volume" "this" {
      - attachment             = [] -> null
      - availability_zone      = "cn-north-4a" -> null
      - cascade                = false -> null
      - description            = "test description" -> null
      - device_type            = "VBD" -> null
      - enterprise_project_id  = "0" -> null
      - id                     = "b72e2ca5-6fd6-4392-89e5-b41bb5e23139" -> null
      - iops                   = 3000 -> null
      - multiattach            = false -> null
      - name                   = "test-volume-name" -> null
      - region                 = "cn-north-4" -> null
      - size                   = 20 -> null
      - status                 = "available" -> null
      - tags                   = {
          - "foo" = "bar"
          - "key" = "value"
        } -> null
      - throughput             = 125 -> null
      - volume_type            = "GPSSD2" -> null
      - wwn                    = "688860315754060120000000023369a4" -> null
        # (3 unchanged attributes hidden)
    }

  # module.evs_snapshot.huaweicloud_evs_snapshot.this[0] will be destroyed
  - resource "huaweicloud_evs_snapshot" "this" {
      - description = "test description" -> null
      - force       = true -> null
      - id          = "7321e434-2777-4b83-9a5d-07454314e451" -> null
      - metadata    = {
          - "meta_key" = "meta_value"
        } -> null
      - name        = "test-snapshot-name" -> null
      - size        = 20 -> null
      - status      = "available" -> null
      - volume_id   = "b72e2ca5-6fd6-4392-89e5-b41bb5e23139" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Changes to Outputs:
  - snapshot_id     = "7321e434-2777-4b83-9a5d-07454314e451" -> null
  - snapshot_size   = 20 -> null
  - snapshot_status = "available" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Destroying... [id=7321e434-2777-4b83-9a5d-07454314e451]
module.evs_snapshot.huaweicloud_evs_snapshot.this[0]: Destruction complete after 3s
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Destroying... [id=b72e2ca5-6fd6-4392-89e5-b41bb5e23139]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still destroying... [id=b72e2ca5-6fd6-4392-89e5-b41bb5e23139, 10s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Destruction complete after 10s

Destroy complete! Resources: 2 destroyed.
```