### PR TITLE
feat(script): add new evs volume transfer module script

### DIFF
--- a/examples/evs-volume-transfer/README.md
+++ b/examples/evs-volume-transfer/README.md
@@ -1,0 +1,65 @@
+# EVS volume transfer example
+
+Configuration in this directory creates an EVS volume transfer.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name                | Source                                                                           | Version |
+|---------------------|----------------------------------------------------------------------------------|---------|
+| evs_volume          | [../../modules/evs-volume](../../modules/evs-volume/README.md)                   | N/A     |
+| evs_volume_transfer | [../../modules/evs-volume-transfer](../../modules/evs-volume-transfer/README.md) | N/A     |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name                                     | Type        |
+|------------------------------------------|-------------|
+| huaweicloud_evs_volume_transfer.this     | resource    |
+| huaweicloud_evs_volume.this              | resource    |
+| data.huaweicloud_availability_zones.this | data-source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                     | Description                                                     | Value                                                 |
+|--------------------------|-----------------------------------------------------------------|-------------------------------------------------------|
+| volume_availability_zone | The availability zone for the EVS volume                        | `"cn-north-4a"`                                       |
+| volume_type              | The EVS volume type                                             | `"GPSSD2"`                                            |
+| volume_iops              | The IOPS(Input/Output Operations Per Second) for the EVS volume | `3000`                                                |
+| volume_throughput        | The throughput for the EVS volume                               | `125`                                                 |
+| volume_device_type       | The device type for the EVS volume                              | `"VBD"`                                               |
+| volume_name              | The EVS volume name                                             | `"volume-test"`                                       |
+| volume_description       | The EVS volume description                                      | `"test description"`                                  |
+| volume_size              | The EVS volume size, in GB                                      | `20`                                                  |
+| volume_multiattach       | Whether the EVS volume is shareable                             | `false`                                               |
+| volume_tags              | The key/value pairs to associate with the EVS volume            | <pre>{<br>  foo = "bar"<br>  key = "value"<br>}</pre> |
+| volume_transfer_name     | The name of the volume transfer record                          | `"test-volume-transfer-name"`                         |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                       | Description                                                        |
+|----------------------------|--------------------------------------------------------------------|
+| volume_transfer_id         | The resource ID in UUID format                                     |
+| volume_transfer_auth_key   | The identity authentication key for volume transfer                |
+| volume_transfer_created_at | The creation time of the volume transfer record, in RFC3339 format |

--- a/examples/evs-volume-transfer/main.tf
+++ b/examples/evs-volume-transfer/main.tf
@@ -1,0 +1,23 @@
+data "huaweicloud_availability_zones" "this" {}
+
+module "evs_postpaid_volume" {
+  source = "../../modules/evs-volume"
+
+  volume_availability_zone = var.volume_availability_zone != null ? var.volume_availability_zone : try(data.huaweicloud_availability_zones.this.names[0], "")
+  volume_type              = var.volume_type
+  volume_iops              = var.volume_iops
+  volume_throughput        = var.volume_throughput
+  volume_device_type       = var.volume_device_type
+  volume_name              = var.volume_name
+  volume_description       = var.volume_description
+  volume_size              = var.volume_size
+  volume_multiattach       = var.volume_multiattach
+  volume_tags              = var.volume_tags
+}
+
+module "evs_volume_transfer" {
+  source = "../../modules/evs-volume-transfer"
+
+  volume_transfer_volume_id = module.evs_postpaid_volume.volume_id
+  volume_transfer_name = var.volume_transfer_name
+}

--- a/examples/evs-volume-transfer/outputs.tf
+++ b/examples/evs-volume-transfer/outputs.tf
@@ -1,0 +1,15 @@
+output "volume_transfer_id" {
+  description = "The resource ID in UUID format"
+  value       = module.evs_volume_transfer.volume_transfer_id
+}
+
+output "volume_transfer_auth_key" {
+  description = "The identity authentication key for volume transfer"
+  value       = module.evs_volume_transfer.volume_transfer_auth_key
+  sensitive   = true
+}
+
+output "volume_transfer_created_at" {
+  description = "The creation time of the volume transfer record, in RFC3339 format"
+  value       = module.evs_volume_transfer.volume_transfer_created_at
+}

--- a/examples/evs-volume-transfer/variables.json
+++ b/examples/evs-volume-transfer/variables.json
@@ -1,0 +1,15 @@
+{
+  "volume_type": "GPSSD2",
+  "volume_iops": 3000,
+  "volume_throughput": 125,
+  "volume_device_type": "VBD",
+  "volume_name": "test-volume-name",
+  "volume_description": "test description",
+  "volume_size": 20,
+  "volume_multiattach": false,
+  "volume_tags": {
+    "foo": "bar",
+    "key": "value"
+  },
+  "volume_transfer_name": "test-volume-transfer-name"
+}

--- a/examples/evs-volume-transfer/variables.tf
+++ b/examples/evs-volume-transfer/variables.tf
@@ -1,0 +1,71 @@
+######################################################################
+# Configurations of EVS volume
+######################################################################
+variable "volume_availability_zone" {
+  type        = string
+  description = "The availability zone for the EVS volume"
+  default     = null
+}
+
+variable "volume_type" {
+  type        = string
+  description = "The EVS volume type"
+  default     = null
+}
+
+variable "volume_iops" {
+  type        = number
+  description = "The IOPS(Input/Output Operations Per Second) for the EVS volume"
+  default     = null
+}
+
+variable "volume_throughput" {
+  type        = number
+  description = "The throughput for the EVS volume"
+  default     = null
+}
+
+variable "volume_device_type" {
+  type        = string
+  description = "The device type for the EVS volume"
+  default     = null
+}
+
+variable "volume_name" {
+  type        = string
+  description = "The EVS volume name"
+  default     = null
+}
+
+variable "volume_description" {
+  type        = string
+  description = "The EVS volume description"
+  default     = null
+}
+
+variable "volume_size" {
+  type        = number
+  description = "The EVS volume size, in GB"
+  default     = null
+}
+
+variable "volume_multiattach" {
+  type        = bool
+  description = "Whether the EVS volume is shareable"
+  default     = null
+}
+
+variable "volume_tags" {
+  type        = map(string)
+  description = "The key/value pairs to associate with the EVS volume"
+  default     = null
+}
+
+######################################################################
+# Configurations of EVS volume transfer
+######################################################################
+variable "volume_transfer_name" {
+  type        = string
+  description = "The name of the volume transfer record"
+  default     = null
+}

--- a/examples/evs-volume-transfer/versions.tf
+++ b/examples/evs-volume-transfer/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/evs-volume-transfer/README.md
+++ b/modules/evs-volume-transfer/README.md
@@ -1,0 +1,92 @@
+# EVS volume transfer management
+
+Manages the EVS volume transfer resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+Please make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages an EVS volume transfer.
+module "evs_volume_transfer" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/modules/evs-volume-transfer"
+
+  ...
+}
+```
+
+Execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0] "volume_transfer_id"
+
+module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Importing from ID "volume_transfer_id"...
+module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Import prepared!
+  Prepared huaweicloud_evs_volume_transfer for import
+module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Refreshing state... [id=volume_transfer_id]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+### What should we do before deploy this module example
+
+Before manage EVS resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret
+key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK
+information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in
+the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-evs/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../.github/how_to_contribute.md).
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name                                 | Type     |
+|--------------------------------------|----------|
+| huaweicloud_evs_volume_transfer.this | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                      | Description                                                                                                         | Type     | Default |                          Required                          |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------|----------|:-------:|:----------------------------------------------------------:|
+| is_volume_transfer_create | Controls whether the EVS volume transfer should be created (it affects all EVS related resources under this module) | `bool`   | `true`  |                             N                              |
+| volume_transfer_volume_id | The volume ID to be transferred                                                                                     | `string` | `null`  | Y (Unless is_volume_transfer_create is specified as false) |
+| volume_transfer_name      | The name of the volume transfer record                                                                              | `string` | `null`  | Y (Unless is_volume_transfer_create is specified as false) |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                       | Description                                                        |
+|----------------------------|--------------------------------------------------------------------|
+| volume_transfer_id         | The resource ID in UUID format                                     |
+| volume_transfer_auth_key   | The identity authentication key for volume transfer                |
+| volume_transfer_created_at | The creation time of the volume transfer record, in RFC3339 format |

--- a/modules/evs-volume-transfer/main.tf
+++ b/modules/evs-volume-transfer/main.tf
@@ -1,0 +1,6 @@
+resource "huaweicloud_evs_volume_transfer" "this" {
+  count = var.is_volume_transfer_create ? 1 : 0
+
+  volume_id = var.volume_transfer_volume_id
+  name      = var.volume_transfer_name
+}

--- a/modules/evs-volume-transfer/outputs.tf
+++ b/modules/evs-volume-transfer/outputs.tf
@@ -1,0 +1,15 @@
+output "volume_transfer_id" {
+  description = "The resource ID in UUID format"
+  value       = try(huaweicloud_evs_volume_transfer.this[0].id, "")
+}
+
+output "volume_transfer_auth_key" {
+  description = "The identity authentication key for volume transfer"
+  value       = try(huaweicloud_evs_volume_transfer.this[0].auth_key, "")
+  sensitive   = true
+}
+
+output "volume_transfer_created_at" {
+  description = "The creation time of the volume transfer record, in RFC3339 format"
+  value       = try(huaweicloud_evs_volume_transfer.this[0].created_at, "")
+}

--- a/modules/evs-volume-transfer/variables.tf
+++ b/modules/evs-volume-transfer/variables.tf
@@ -1,0 +1,22 @@
+######################################################################
+# Configurations of EVS volume transfer
+######################################################################
+
+variable "is_volume_transfer_create" {
+  type        = bool
+  description = "Controls whether the EVS volume transfer should be created (it affects all EVS related resources under this module)"
+  default     = true
+  nullable    = false
+}
+
+variable "volume_transfer_volume_id" {
+  type        = string
+  description = "The volume ID to be transferred"
+  default     = null
+}
+
+variable "volume_transfer_name" {
+  type        = string
+  description = "The name of the volume transfer record"
+  default     = null
+}

--- a/modules/evs-volume-transfer/versions.tf
+++ b/modules/evs-volume-transfer/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
# add new evs volume transfer module script.
## test running evs volume transfer module
```
terraform apply -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.evs_postpaid_volume.huaweicloud_evs_volume.this[0] will be created
  + resource "huaweicloud_evs_volume" "this" {
      + attachment             = (known after apply)
      + availability_zone      = "cn-north-4a"
      + cascade                = false
      + charging_mode          = (known after apply)
      + dedicated_storage_name = (known after apply)
      + description            = "test description"
      + device_type            = "VBD"
      + enterprise_project_id  = (known after apply)
      + id                     = (known after apply)
      + iops                   = 3000
      + multiattach            = false
      + name                   = "test-volume-name"
      + region                 = (known after apply)
      + size                   = 20
      + status                 = (known after apply)
      + tags                   = {
          + "foo" = "bar"
          + "key" = "value"
        }
      + throughput             = 125
      + volume_type            = "GPSSD2"
      + wwn                    = (known after apply)
    }

  # module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0] will be created
  + resource "huaweicloud_evs_volume_transfer" "this" {
      + auth_key   = (sensitive value)
      + created_at = (known after apply)
      + id         = (known after apply)
      + name       = "test-volume-transfer-name"
      + region     = (known after apply)
      + volume_id  = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + volume_transfer_auth_key   = (sensitive value)
  + volume_transfer_created_at = (known after apply)
  + volume_transfer_id         = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Creating...
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still creating... [10s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Creation complete after 14s [id=c204e538-d95f-4aab-8f57-9e00fa50ce6d]
module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Creating...
module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Creation complete after 0s [id=2e345b04-028f-4330-ace3-f896f4079e6d]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

volume_transfer_auth_key = <sensitive>
volume_transfer_created_at = "2025-03-27T15:19:40+08:00"
volume_transfer_id = "2e345b04-028f-4330-ace3-f896f4079e6d"
```

## test destroying evs volume transfer module
```
terraform destroy -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 1s [id=74326821]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Refreshing state... [id=c204e538-d95f-4aab-8f57-9e00fa50ce6d]
module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Refreshing state... [id=2e345b04-028f-4330-ace3-f896f4079e6d]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # module.evs_postpaid_volume.huaweicloud_evs_volume.this[0] will be destroyed
  - resource "huaweicloud_evs_volume" "this" {
      - attachment             = [] -> null
      - availability_zone      = "cn-north-4a" -> null
      - cascade                = false -> null
      - description            = "test description" -> null
      - device_type            = "VBD" -> null
      - enterprise_project_id  = "0" -> null
      - id                     = "c204e538-d95f-4aab-8f57-9e00fa50ce6d" -> null
      - iops                   = 3000 -> null
      - multiattach            = false -> null
      - name                   = "test-volume-name" -> null
      - region                 = "cn-north-4" -> null
      - size                   = 20 -> null
      - status                 = "awaiting-transfer" -> null
      - tags                   = {
          - "foo" = "bar"
          - "key" = "value"
        } -> null
      - throughput             = 125 -> null
      - volume_type            = "GPSSD2" -> null
      - wwn                    = "688860313762639600000000095629a0" -> null
        # (3 unchanged attributes hidden)
    }

  # module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0] will be destroyed
  - resource "huaweicloud_evs_volume_transfer" "this" {
      - auth_key   = (sensitive value) -> null
      - created_at = "2025-03-27T15:19:40+08:00" -> null
      - id         = "2e345b04-028f-4330-ace3-f896f4079e6d" -> null
      - name       = "test-volume-transfer-name" -> null
      - region     = "cn-north-4" -> null
      - volume_id  = "c204e538-d95f-4aab-8f57-9e00fa50ce6d" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Changes to Outputs:
  - volume_transfer_auth_key   = (sensitive value) -> null
  - volume_transfer_created_at = "2025-03-27T15:19:40+08:00" -> null
  - volume_transfer_id         = "2e345b04-028f-4330-ace3-f896f4079e6d" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Destroying... [id=2e345b04-028f-4330-ace3-f896f4079e6d]
module.evs_volume_transfer.huaweicloud_evs_volume_transfer.this[0]: Destruction complete after 0s
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Destroying... [id=c204e538-d95f-4aab-8f57-9e00fa50ce6d]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Still destroying... [id=c204e538-d95f-4aab-8f57-9e00fa50ce6d, 10s elapsed]
module.evs_postpaid_volume.huaweicloud_evs_volume.this[0]: Destruction complete after 11s

Destroy complete! Resources: 2 destroyed.
```


